### PR TITLE
Fix for unsuccessful DataIntegrityViolationException catching in services

### DIFF
--- a/src/main/java/com/seitov/messenger/service/AttachmentService.java
+++ b/src/main/java/com/seitov/messenger/service/AttachmentService.java
@@ -22,7 +22,7 @@ public class AttachmentService {
 
     public Attachment create(Attachment attachment) throws IllegalDataFormatException {
         try {
-            return attachmentRepository.save(attachment);
+            return attachmentRepository.saveAndFlush(attachment);
         } catch (DataIntegrityViolationException e) {
             throw new IllegalDataFormatException("Attachment's filename must not be empty!", e.getCause());
         }

--- a/src/main/java/com/seitov/messenger/service/ChannelService.java
+++ b/src/main/java/com/seitov/messenger/service/ChannelService.java
@@ -32,7 +32,7 @@ public class ChannelService {
 
     public Channel create(Channel toCreate) throws IllegalDataFormatException {
         try {
-            return channelRepository.save(toCreate);
+            return channelRepository.saveAndFlush(toCreate);
         } catch (DataIntegrityViolationException e) {
             throw new IllegalDataFormatException("Name and accessType cannot be null!");
         }
@@ -48,7 +48,7 @@ public class ChannelService {
 
     public Channel update(Channel channel) throws IllegalDataFormatException {
         try {
-            return channelRepository.save(channel);   
+            return channelRepository.saveAndFlush(channel);   
         } catch (DataIntegrityViolationException e) {
             throw new IllegalDataFormatException("Error occured while attempting to update this channel!", e.getCause());
         }

--- a/src/main/java/com/seitov/messenger/service/FriendshipService.java
+++ b/src/main/java/com/seitov/messenger/service/FriendshipService.java
@@ -36,7 +36,7 @@ public class FriendshipService {
             friendship.setUser(pair.get(user));
             friendship.setFriend(pair.get(friend));
             friendship.setStatus(Status.pending);
-            friendshipRepository.save(friendship);   
+            friendshipRepository.saveAndFlush(friendship);   
             return friendship;
         } catch (DataIntegrityViolationException e) {
             throw new IllegalDataException("Request to this user already sent!");

--- a/src/main/java/com/seitov/messenger/service/MembershipService.java
+++ b/src/main/java/com/seitov/messenger/service/MembershipService.java
@@ -36,7 +36,7 @@ public class MembershipService {
             membership.setChannel(channel);
             membership.setUser(user);
             membership.setRole(role);
-            membershipRepository.save(membership);
+            membershipRepository.saveAndFlush(membership);
             return membership;
         } catch (DataIntegrityViolationException e){
             throw new ResourceAlreadyExistsException("User already exist on this server!", e.getCause());

--- a/src/main/java/com/seitov/messenger/service/RoomService.java
+++ b/src/main/java/com/seitov/messenger/service/RoomService.java
@@ -38,7 +38,7 @@ public class RoomService {
 
     public Room create(Room room) throws IllegalDataFormatException {
         try {
-            return roomRepository.save(room);
+            return roomRepository.saveAndFlush(room);
         } catch (DataIntegrityViolationException e) {
             throw new IllegalDataFormatException("Error occured while attempting to create new room!", e.getCause());
         }
@@ -62,7 +62,7 @@ public class RoomService {
         message.setTimestamp(LocalDateTime.now());
         message.setUser(user);
         try { 
-            return messageRepository.save(message);   
+            return messageRepository.saveAndFlush(message);   
         } catch (DataIntegrityViolationException e) {
             throw new IllegalDataFormatException("Error occured while attempting to save new message!", e.getCause());
         }

--- a/src/main/java/com/seitov/messenger/service/UserService.java
+++ b/src/main/java/com/seitov/messenger/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
 
     public User update(User user) throws IllegalDataFormatException, IllegalDataException {
         try {
-            return userRepository.save(user);
+            return userRepository.saveAndFlush(user);
         } catch (IllegalArgumentException e) {
             throw new IllegalDataFormatException("User for update must not be null!", e.getCause());
         } catch (DataIntegrityViolationException e) {
@@ -68,7 +68,7 @@ public class UserService {
         }
         user.setPassword(passwordEncoder.encode(updatePasswordDto.getNewPassword()));
         try {
-            return userRepository.save(user);   
+            return userRepository.saveAndFlush(user);   
         } catch (DataIntegrityViolationException e) {
             throw new IllegalDataFormatException("Illegal User entity received!", e.getCause());
         }

--- a/src/test/java/com/seitov/messenger/service/AttachmentServiceTests.java
+++ b/src/test/java/com/seitov/messenger/service/AttachmentServiceTests.java
@@ -48,7 +48,7 @@ public class AttachmentServiceTests {
     public void createWithEmptyFilename() {
         Attachment attachment = new Attachment();
         attachment.setFilename("");
-        when(attachmentRepository.save(attachment)).thenThrow(DataIntegrityViolationException.class);
+        when(attachmentRepository.saveAndFlush(attachment)).thenThrow(DataIntegrityViolationException.class);
         Exception ex = assertThrows(IllegalDataFormatException.class, () -> attachmentService.create(attachment));
         assertEquals("Attachment's filename must not be empty!", ex.getMessage());
     }
@@ -57,7 +57,7 @@ public class AttachmentServiceTests {
     public void createWithValidFilename() {
         Attachment attachment = new Attachment();
         attachment.setFilename("filename.pdf");
-        when(attachmentRepository.save(attachment)).thenReturn(attachment);
+        when(attachmentRepository.saveAndFlush(attachment)).thenReturn(attachment);
         assertEquals(attachmentService.create(attachment), attachment);
     }
 

--- a/src/test/java/com/seitov/messenger/service/ChannelServiceTests.java
+++ b/src/test/java/com/seitov/messenger/service/ChannelServiceTests.java
@@ -40,14 +40,14 @@ public class ChannelServiceTests {
     @Test
     public void createChannel() {
         Channel channel = new Channel(UUID.randomUUID(), "Channel", null, null, AccessType.closed);
-        when(channelRepository.save(channel)).thenReturn(channel);
+        when(channelRepository.saveAndFlush(channel)).thenReturn(channel);
         assertEquals(channel, channelService.create(channel));
     }
 
     @Test
     public void createChannelWithNullRequiredFields() {
         Channel channel = new Channel(null, "Channel", new Image(), "description", null);
-        when(channelRepository.save(channel)).thenThrow(DataIntegrityViolationException.class);
+        when(channelRepository.saveAndFlush(channel)).thenThrow(DataIntegrityViolationException.class);
         Exception ex = assertThrows(IllegalDataFormatException.class, () -> channelService.create(channel));
         assertEquals("Name and accessType cannot be null!", ex.getMessage());
     }

--- a/src/test/java/com/seitov/messenger/service/FriendshipServiceTests.java
+++ b/src/test/java/com/seitov/messenger/service/FriendshipServiceTests.java
@@ -53,7 +53,7 @@ public class FriendshipServiceTests {
         User friend = new User();
         mockUserServiceGetPair(user, friend);
         Friendship friendship = new Friendship(null, user, friend, Status.pending);
-        when(friendshipRepository.save(friendship)).thenThrow(DataIntegrityViolationException.class);
+        when(friendshipRepository.saveAndFlush(friendship)).thenThrow(DataIntegrityViolationException.class);
         when(userService.getUserPair("user", "friend"))
                 .thenReturn(Map.of(user.getUsername(), user, friend.getUsername(), friend));
         Exception ex = assertThrows(IllegalDataException.class,

--- a/src/test/java/com/seitov/messenger/service/MembershipServiceTests.java
+++ b/src/test/java/com/seitov/messenger/service/MembershipServiceTests.java
@@ -40,7 +40,7 @@ public class MembershipServiceTests {
         Channel channel = new Channel(UUID.randomUUID(), "channel", null, null, AccessType.open);
         User user = new User(UUID.randomUUID(), "user", "pass", null, "USER");
         Membership membership = new Membership(user, channel, Role.founder);
-        when(membershipRepository.save(any(Membership.class))).thenAnswer(i -> i.getArguments()[0]);
+        when(membershipRepository.saveAndFlush(any(Membership.class))).thenAnswer(i -> i.getArguments()[0]);
         Membership created = membershipService.create(channel, user, Role.founder);
         assertEquals(membership.getUser(), created.getUser());
         assertEquals(membership.getChannel(), created.getChannel());
@@ -51,7 +51,7 @@ public class MembershipServiceTests {
     public void createDuplicate() {
         Channel channel = new Channel(UUID.randomUUID(), "channel", null, null, AccessType.open);
         User user = new User(UUID.randomUUID(), "user", "pass", null, "USER");
-        when(membershipRepository.save(any(Membership.class))).thenThrow(DataIntegrityViolationException.class);
+        when(membershipRepository.saveAndFlush(any(Membership.class))).thenThrow(DataIntegrityViolationException.class);
         Exception ex = assertThrows(ResourceAlreadyExistsException.class, () -> membershipService.create(channel, user, Role.user));
         assertEquals("User already exist on this server!", ex.getMessage());
     }

--- a/src/test/java/com/seitov/messenger/service/RoomServiceTests.java
+++ b/src/test/java/com/seitov/messenger/service/RoomServiceTests.java
@@ -65,7 +65,7 @@ public class RoomServiceTests {
         message.setRoom(room);
         User user = new User(UUID.randomUUID(), "user", "pass", null, "USER");
         when(membershipService.checkPermissions(openChannel, user, 0)).thenReturn(0);
-        when(messageRepository.save(any(Message.class))).thenAnswer(i -> i.getArguments()[0]);
+        when(messageRepository.saveAndFlush(any(Message.class))).thenAnswer(i -> i.getArguments()[0]);
         Message savedMessage = roomService.newMessage(user, message);
         message.setTimestamp(LocalDateTime.now());
         assertEquals(message, savedMessage);

--- a/src/test/java/com/seitov/messenger/service/UserServiceTests.java
+++ b/src/test/java/com/seitov/messenger/service/UserServiceTests.java
@@ -83,7 +83,7 @@ public class UserServiceTests {
         user.setUsername("user");
         user.setPassword(passwordEncoder.encode("pass"));
         updatePasswordDto.setMatchingPassword("newPass");
-        when(userRepository.save(user)).thenReturn(user);
+        when(userRepository.saveAndFlush(user)).thenReturn(user);
         assertEquals(user, userService.updatePassword(user, updatePasswordDto));
     }
 
@@ -121,14 +121,14 @@ public class UserServiceTests {
         User user = new User();
         user.setUsername("username");
         user.setPassword("password");
-        when(userRepository.save(null)).thenThrow(IllegalArgumentException.class);
-        when(userRepository.save(illegalUser)).thenThrow(DataIntegrityViolationException.class);
+        when(userRepository.saveAndFlush(null)).thenThrow(IllegalArgumentException.class);
+        when(userRepository.saveAndFlush(illegalUser)).thenThrow(DataIntegrityViolationException.class);
         Exception ex;
         ex = assertThrows(IllegalDataFormatException.class, () -> userService.update(null));
         assertEquals("User for update must not be null!", ex.getMessage());
         ex = assertThrows(IllegalDataFormatException.class, () -> userService.update(illegalUser));
         assertEquals("Illegal User entity received!", ex.getMessage());
-        when(userRepository.save(user)).thenReturn(user);
+        when(userRepository.saveAndFlush(user)).thenReturn(user);
         assertEquals(user, userService.update(user));
     }
 


### PR DESCRIPTION
Replaces save() to saveAndFlush() in services in case if service trying to catch DataIntegrityViolationException